### PR TITLE
Fix gauge example interval function's invalid reference

### DIFF
--- a/examples/gauge.go
+++ b/examples/gauge.go
@@ -31,7 +31,7 @@ func gaugeTimer() *charts.Gauge {
 
 	fn := fmt.Sprintf(`setInterval(function () {
 			option_%s.series[0].data[0].value = (Math.random() * 100).toFixed(2) - 0;
-			myChart_%s.setOption(option_%s, true);
+			goecharts_%s.setOption(option_%s, true);
 		}, 2000);`, gauge.ChartID, gauge.ChartID, gauge.ChartID)
 	gauge.AddJSFuncs(fn)
 	return gauge


### PR DESCRIPTION
Fixes reference error

![image](https://user-images.githubusercontent.com/12990590/120065884-4e799280-c07c-11eb-8548-b83ffc832949.png)
