### PR TITLE
Add treemap type graph example

### DIFF
--- a/examples/treemap.go
+++ b/examples/treemap.go
@@ -1,0 +1,143 @@
+package examples
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+
+	"github.com/go-echarts/go-echarts/v2/charts"
+	"github.com/go-echarts/go-echarts/v2/components"
+	"github.com/go-echarts/go-echarts/v2/opts"
+	"github.com/go-echarts/go-echarts/v2/types"
+)
+
+var TreeMap = []opts.TreeMapNode{
+	{
+		Name:     "d1",
+		Children: []opts.TreeMapNode{{Name: "f1", Value: 1000}},
+	},
+	{
+		Name:  "d2",
+		Children: []opts.TreeMapNode{
+			{Name: "f1", Value: 100},
+			{Name: "f2", Value: 300},
+			{Name: "f3", Value: 200},
+		},
+	},
+	{
+		Name:  "d3",
+		// Children populated later.
+	},
+	{
+		Name:  "f1",
+		Value: 450,
+	},
+}
+
+var ToolTipFormatter = `
+function (info) {
+	var formatUtil = echarts.format;
+	var value = info.value;
+	var treePathInfo = info.treePathInfo;
+	var treePath = [];
+	for (var i = 1; i < treePathInfo.length; i++) {
+		treePath.push(treePathInfo[i].name);
+	}
+	return ['<div class="tooltip-title">' + formatUtil.encodeHTML(treePath.join('/')) + '</div>',
+		'Disk Usage: ' + formatUtil.addCommas(value) + ' KB',
+		].join('');
+}
+`
+
+func treeMapBase() *charts.TreeMap {
+	graph := charts.NewTreeMap()
+	graph.SetGlobalOptions(
+		charts.WithInitializationOpts(opts.Initialization{Theme: types.ThemeMacarons}),
+		charts.WithTitleOpts(opts.Title{
+			Title:    "Basic treemap example",
+			Subtitle: "File system usage",
+			Left:     "center",
+		}),
+		charts.WithTooltipOpts(opts.Tooltip{
+			Show:      true,
+			Formatter: opts.FuncOpts(ToolTipFormatter),
+		}),
+		charts.WithToolboxOpts(opts.Toolbox{
+			Show:   true,
+			Orient: "horizontal",
+			Left:   "right",
+			Feature: &opts.ToolBoxFeature{
+				SaveAsImage: &opts.ToolBoxFeatureSaveAsImage{
+					Show: true, Title: "Save as image"},
+				Restore: &opts.ToolBoxFeatureRestore{
+					Show: true, Title: "Reset"},
+			}}),
+	)
+	// Populate "d3" node with large number of small-sized files.
+	d3Index := 2
+	d3NumFiles := 40
+	TreeMap[d3Index].Children = make([]opts.TreeMapNode, d3NumFiles)
+	for i := range TreeMap[d3Index].Children {
+		TreeMap[d3Index].Children[i] = opts.TreeMapNode{
+			Name:  fmt.Sprintf("f%v", i),
+			Value: 5 + rand.Intn(15-5),
+		}
+	}
+	// Add initialized data to graph.
+	graph.AddSeries("Root FS", TreeMap).
+		SetSeriesOptions(
+			charts.WithTreeMapOpts(
+				opts.TreeMapChart{
+					Animation:  true,
+					Roam:       true,
+					UpperLabel: &opts.UpperLabel{Show: true},
+					Levels: &[]opts.TreeMapLevel{
+						{ // Series
+							ItemStyle: &opts.ItemStyle{
+								BorderColor: "#777",
+								BorderWidth: 1,
+								GapWidth:    1},
+							UpperLabel: &opts.UpperLabel{Show: false},
+						},
+						{ // Level
+							ItemStyle: &opts.ItemStyle{
+								BorderColor: "#666",
+								BorderWidth: 2,
+								GapWidth:    1},
+							Emphasis: &opts.Emphasis{
+								ItemStyle: &opts.ItemStyle{BorderColor: "#555"},
+							},
+						},
+						{ // Node
+							ColorSaturation: []float32{0.35, 0.5},
+							ItemStyle: &opts.ItemStyle{
+								GapWidth:              1,
+								BorderWidth:           0,
+								BorderColorSaturation: 0.6,
+							},
+						},
+					},
+				},
+			),
+			charts.WithItemStyleOpts(opts.ItemStyle{BorderColor: "#fff"}),
+			charts.WithLabelOpts(opts.Label{Show: true, Position: "inside", Color: "White"}),
+		)
+	return graph
+}
+
+type TreeMapExamples struct{}
+
+func (TreeMapExamples) Examples() {
+	page := components.NewPage()
+	page.AddCharts(
+		treeMapBase(),
+	)
+
+	f, err := os.Create("examples/html/treemap.html")
+	if err != nil {
+		panic(err)
+
+	}
+	page.Render(io.MultiWriter(f))
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-echarts/examples
 
 go 1.15
 
-require github.com/go-echarts/go-echarts/v2 v2.2.4
+require github.com/go-echarts/go-echarts/v2 v2.2.5-0.20211021024243-33ae1aa415d6
 
 // dev mode
 //replace (

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-echarts/go-echarts/v2 v2.2.4 h1:SKJpdyNIyD65XjbUZjzg6SwccTNXEgmh+PlaO23g2H0=
 github.com/go-echarts/go-echarts/v2 v2.2.4/go.mod h1:6TOomEztzGDVDkOSCFBq3ed7xOYfbOqhaBzD0YV771A=
+github.com/go-echarts/go-echarts/v2 v2.2.5-0.20211021024243-33ae1aa415d6 h1:+p0u+1svKoBC2xS6GzpmcDHShkAGqD+wUQLpxIpygM0=
+github.com/go-echarts/go-echarts/v2 v2.2.5-0.20211021024243-33ae1aa415d6/go.mod h1:6TOomEztzGDVDkOSCFBq3ed7xOYfbOqhaBzD0YV771A=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 		examples.SunburstExample{},
 		examples.Surface3dExamples{},
 		examples.TreeExamples{},
+		examples.TreeMapExamples{},
 		examples.ThemeriverExamples{},
 		examples.ThemeExamples{},
 		examples.WordcloudExamples{},


### PR DESCRIPTION
This patch adds an example to illustrate go-echarts usage for generating
treemap type graph, using a simple "show file system usage" popular use-case.

This example requires a bump in go-echarts go module dependency
(which previously did not support wrappers for ECharts treemap).

---

Tested the patch as:
```
$ go version
go version go1.16.6 darwin/amd64
$ go run main.go
2021/10/20 22:22:33 running server at http://localhost:8089
2021/10/20 22:23:12 127.0.0.1:51714 GET /
2021/10/20 22:23:14 127.0.0.1:51714 GET /treemap.html
```
and verified generated `examples/html/treemap.html` file from above http web server is accessible and viewable from a web browser, graph rendered correctly.
<img width="1165" alt="treemap" src="https://user-images.githubusercontent.com/84156354/138216618-2601544c-eb88-44fd-9bfc-834555b1fa92.png">
