### PR TITLE
Fix boxplot example to render data correctly

### DIFF
--- a/examples/boxplot.go
+++ b/examples/boxplot.go
@@ -7,11 +7,12 @@ import (
 	"github.com/go-echarts/go-echarts/v2/charts"
 	"github.com/go-echarts/go-echarts/v2/components"
 	"github.com/go-echarts/go-echarts/v2/opts"
+	"github.com/montanaflynn/stats"
 )
 
 var (
 	bpX = [...]string{"expr1", "expr2", "expr3", "expr4", "expr5"}
-	bpY = [][]int{
+	bpY = [][]float64{
 		{850, 740, 900, 1070, 930, 850, 950, 980, 980, 880, 1000, 980, 930, 650, 760, 810, 1000, 1000, 960, 960},
 		{960, 940, 960, 940, 880, 800, 850, 880, 900, 840, 830, 790, 810, 880, 880, 830, 800, 790, 760, 800},
 		{880, 880, 880, 860, 720, 720, 620, 860, 970, 950, 880, 910, 850, 870, 840, 840, 850, 840, 840, 840},
@@ -20,10 +21,24 @@ var (
 	}
 )
 
-func generateBoxPlotItems(boxPlotData [][]int) []opts.BoxPlotData {
+func createBoxPlotData(data []float64) []float64 {
+	min, _ := stats.Min(data)
+	max, _ := stats.Max(data)
+	q, _ := stats.Quartile(data)
+
+	return []float64{
+		min,
+		q.Q1,
+		q.Q2,
+		q.Q3,
+		max,
+	}
+}
+
+func generateBoxPlotItems(boxPlotData [][]float64) []opts.BoxPlotData {
 	items := make([]opts.BoxPlotData, 0)
 	for i := 0; i < len(boxPlotData); i++ {
-		items = append(items, opts.BoxPlotData{Value: boxPlotData[i]})
+		items = append(items, opts.BoxPlotData{Value: createBoxPlotData(boxPlotData[i])})
 	}
 	return items
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require github.com/go-echarts/go-echarts/v2 v2.4.0-rc2
 
+require github.com/montanaflynn/stats v0.7.1
+
 // dev mode
 //replace github.com/go-echarts/go-echarts/v2 => ../../go-echarts
 //

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/go-echarts/go-echarts/v2 v2.4.0-rc2 h1:Od2aC5TsRf+HKoh0MHkdg2zIUXPfzB9GC4kEWTLSHAk=
 github.com/go-echarts/go-echarts/v2 v2.4.0-rc2/go.mod h1:56YlvzhW/a+du15f3S2qUGNDfKnFOeJSThBIrVFHDtI=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=


### PR DESCRIPTION
Original author incorrectly assumed that the e-charts library would compute the quartile values for you. However according to
https://echarts.apache.org/en/option.html#series-boxplot.data and subsequent verification with the example data I determined it was not doing this. Thus this patch now exists to show a correct working example of box plots with the original example provided by the author.